### PR TITLE
feat: collect GitHub Copilot CLI sessions

### DIFF
--- a/.agents/skills/nippo/SKILL.md
+++ b/.agents/skills/nippo/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: "nippo"
-description: "Generate Japanese daily reports, reflection prompts, guides, reviews, and trend reports from Claude Code or Codex work logs. Use when the user asks for nippo, 日報, daily, reflection, guide, report, review, insight, trend, plan, ledger, or wants to summarize recent Claude Code/Codex work."
+description: "Generate Japanese daily reports, reflection prompts, guides, reviews, and trend reports from Claude Code, Codex, or GitHub Copilot work logs. Use when the user asks for nippo, 日報, daily, reflection, guide, report, review, insight, trend, plan, ledger, or wants to summarize recent agent work."
 ---
 
 # Nippo
 
-Use this skill when the user wants to turn recent Claude Code or Codex work into a report under `reports/`.
+Use this skill when the user wants to turn recent Claude Code, Codex, or GitHub Copilot work into a report under `reports/`.
 
 ## Inputs
 
 - mode: default, `daily`, `brief`, `reflection`, `guide`, `report`, `review`, `insight`, `trend`, `plan`, `ledger`
 - optional days
 - optional project filter
-- optional source override: `claude`, `codex`, `all`
+- optional source override: `claude`, `codex`, `copilot`, `all`
 
 Examples:
 
@@ -20,6 +20,7 @@ Examples:
 - `$nippo daily codex`
 - `$nippo daily claude`
 - `$nippo daily all`
+- `/nippo daily copilot`
 - `$nippo review 90 codex`
 
 ## Workflow
@@ -28,7 +29,7 @@ Examples:
 2. Otherwise prefer `nippo collect ...` when `nippo` is already installed.
 3. If neither is available, stop and tell the user to install `nippo`.
 4. Treat `daily` as an alias of the default daily report mode.
-5. Default to `--source auto`. Override when the user explicitly asks for `claude`, `codex`, or `all`. The collector removes deterministic prompt noise by default; do not pass `--include-prompt-noise` during report generation.
+5. Default to `--source auto`. Override when the user explicitly asks for `claude`, `codex`, `copilot`, or `all`. The collector removes deterministic prompt noise by default; do not pass `--include-prompt-noise` during report generation.
 6. For `brief`, save the summary output directly and stop.
 7. For `ledger`, do NOT call `nippo collect`. Run `nippo ledger` (or `cargo run -q -p nippo -- ledger`) which scans `reports/nippo-*.md` (daily reports) for the `## Unclear points` section, folds them into `reports/ledger.yaml`, and prints a CONVERGED / DIVERGENCE-SIGNAL / CONTINUE verdict. Relay that verdict back to the user verbatim; do not over-interpret. If the user asks for agent-config candidates, run `nippo ledger --export`: it writes recurring General Fix Rules to `reports/ledger-export.md`. Tell the user these are candidates only — a human must curate them before copying anything into CLAUDE.md / AGENTS.md.
 8. For `plan`, do NOT call `nippo collect`. Find the newest `reports/nippo-*.md` by the date in its filename and read it. Also read `reports/ledger.yaml` if present and use unresolved recurring General Fix Rules as candidate material. Read [docs/templates/plan-template.md](docs/templates/plan-template.md) and [docs/reflection-theory.md](docs/reflection-theory.md), present only 1-3 experiment candidates, leave the choice / reason / first-step fields blank for the user, save to `reports/plan-YYYY-MM-DD.md`, and report the path.
@@ -72,14 +73,15 @@ Examples:
 - For `reflection` and `guide`, also read the same-day `reports/nippo-YYYY-MM-DD.md` if it exists.
 - If the first token is neither a mode name, a number, nor a source selector, treat it as a project filter and run the default daily mode with `--project`.
 - Date boundaries follow the machine's local timezone. `--days 1` and `daily` mean the current local calendar day.
-- Treat one token matching `claude`, `codex`, or `all` as the source selector and pass it through to `--source`.
+- Treat one token matching `claude`, `codex`, `copilot`, or `all` as the source selector and pass it through to `--source`.
 - `Codex` report data comes from `history.jsonl`, `state_5.sqlite`, and rollout data referenced by `rollout_path`. Treat `logs_2.sqlite` as diagnostics only.
 - Codex-derived reports may have sparse assistant/tool metrics. State that explicitly instead of inventing numbers.
+- GitHub Copilot report data comes from `session-state/<session-id>/events.jsonl` with `workspace.yaml` as metadata fallback. Input-token events may be absent from persisted logs; state sparse token metrics explicitly instead of inventing numbers.
 - For daily reports, copy `meta.source`, `meta.total_sessions`, `stats.projects_worked_on`, and `stats.tool_frequency` from the collected JSON instead of inferring them from an older report.
 - In every mode that prints a date range, use `meta.period.from` and `meta.period.to`; do not recalculate the range from the execution date.
 - Cover the activity-heavy projects first. Use `stats.projects_worked_on` order (= `message_count` descending) and give the top 3-5 projects their own section before collapsing anything into `その他`.
 - If you show only a subset of `decisions`, explicitly state `全N件中M件を記載`.
-- The current Claude Code or Codex session is excluded by the collector. Do not manually subtract another session from `meta` or `stats`.
+- The current Claude Code, Codex, or GitHub Copilot session is excluded when its host session ID is available. Do not manually subtract another session from `meta` or `stats`.
 - Sanitize reference links before writing them. Do not copy malformed URL fragments with trailing Japanese text or punctuation.
 
 ## Improvement Issues

--- a/.claude/skills/nippo/SKILL.md
+++ b/.claude/skills/nippo/SKILL.md
@@ -2,7 +2,7 @@
 name: nippo
 description: >
   ユーザーが日報・振り返り・作業まとめ・週報・自己評価を求めたときに、
-  Claude Code / Codex のセッションログから日報・リフレクション・インサイトを生成する。
+  Claude Code / Codex / GitHub Copilot のセッションログから日報・リフレクション・インサイトを生成する。
   /nippo と /nippo daily で日報、/nippo reflection で内省の問い、/nippo guide で学習支援、
   /nippo report で進捗報告、/nippo review で自己評価、/nippo insight で深い振り返り、
   /nippo trend で長期変化分析、/nippo plan で朝の行動実験、
@@ -26,7 +26,7 @@ context: fork
 - 出力先は cwd の `reports/` 配下（なければ `mkdir -p reports`）
 - ファイル名: `reports/{モード}-YYYY-MM-DD.md`（期間 N>1 なら `-Nd` を付与）
 - 日付境界は実行環境のローカルタイムゾーン基準。`--days 1` と `daily` は「今日のローカル日付」を意味する
-- デフォルト source は `auto`。Codex では `history.jsonl` と `state_5.sqlite`、および `rollout_path` が指す rollout データを使う。`logs_2.sqlite` は診断用で、日報の主データソースにはしない
+- デフォルト source は `auto`。Codex では `history.jsonl` と `state_5.sqlite`、および `rollout_path` が指す rollout データを使う。GitHub Copilot では `session-state/<session-id>/events.jsonl` と `workspace.yaml` を使う。`logs_2.sqlite` は診断用で、日報の主データソースにはしない
 - このリポジトリ内で実行している場合は、グローバル `nippo` より `cargo run -q -p nippo -- collect ...` を優先する（ローカル実装が新しい可能性があるため）
 - モードと引数を決める前にデータを先読みしない。同じ条件の収集は 1 回だけ実行する
 - 収集 JSON の一時ファイル `tmp/nippo-raw.json` はレポート保存後に必ず削除する。収集や生成に失敗して停止する場合も削除する
@@ -36,9 +36,10 @@ context: fork
 - 対象期間を記載する全モードで `meta.period.from` と `meta.period.to` を使い、実行日から日付を計算し直さない
 - 日報本文のプロジェクト節は `stats.projects_worked_on` の順（`message_count` 降順）で選ぶ。上位 3〜5 プロジェクトは必ず個別に触れ、残りだけを `その他` にまとめる
 - Codex 由来のレポートは assistant/tool のメトリクスが疎になることがある。数値を捏造せず、疎であることを明示する
+- GitHub Copilot 由来のレポートは永続ログに input token イベントがない場合がある。数値を捏造せず、疎であることを明示する
 - source の解決やデータ欠損について質問されたら `${CLAUDE_SKILL_DIR}/docs/data-sources.md` を Read する
 - `decisions` を一部だけ載せる場合は「全N件中M件を記載」と明記する
-- 現在の Claude Code / Codex セッションはコレクターが除外するため、`meta` や `stats` から手作業でセッション数を引かない
+- 現在の Claude Code / Codex / GitHub Copilot セッションはホストのセッション ID が取得できる場合にコレクターが除外するため、`meta` や `stats` から手作業でセッション数を引かない
 - 参考リンクの URL はそのまま貼らず、末尾の日本語や句読点を落として正しい URL だけを残す
 
 ## モード決定
@@ -62,7 +63,7 @@ context: fork
 
 `daily` は `(空)` と同じ日報モードのエイリアス。出力ファイル名は `reports/nippo-YYYY-MM-DD.md` を使う。
 
-残りトークンのうち `claude` / `codex` / `all` は `--source` に渡す。数値があれば `--days` を置換。それ以外の文字列は `--project` に渡す。先頭単語がモード名・数値・source のいずれでもない場合は日報モードとして扱い、その単語を `--project` に渡す。
+残りトークンのうち `claude` / `codex` / `copilot` / `all` は `--source` に渡す。数値があれば `--days` を置換。それ以外の文字列は `--project` に渡す。先頭単語がモード名・数値・source のいずれでもない場合は日報モードとして扱い、その単語を `--project` に渡す。
 
 ## 収集と生成
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # nippo
 
-Claude Code / Codex の作業履歴から日報・リフレクションを生成するリポジトリ。
-Rust バイナリがデータ収集を担当し、Claude Code と Codex の skill がレポート生成を担当する。
+Claude Code / Codex / GitHub Copilot の作業履歴から日報・リフレクションを生成するリポジトリ。
+Rust バイナリがデータ収集を担当し、各エージェントの skill がレポート生成を担当する。
 
 ## Read First
 
@@ -17,7 +17,7 @@ cargo clippy -p nippo -- -D warnings
 cargo test -p nippo
 ```
 
-- Rust edition 2024、Rust 1.85+ 前提
+- Rust edition 2024、Rust 1.88+ 前提
 - `.unwrap()` は避け、`anyhow::Result` と `?` を使う
 
 ## Change Map
@@ -28,8 +28,9 @@ cargo test -p nippo
 - `crates/collector/src/session.rs`: source 共通のセッション表現
 - `crates/collector/src/sources/claude_code.rs`: Claude Code パーサ
 - `crates/collector/src/sources/codex.rs`: Codex 履歴パーサ
+- `crates/collector/src/sources/copilot.rs`: GitHub Copilot CLI イベントパーサ
 - `.claude/skills/nippo/SKILL.md`: Claude Code 用 skill
-- `.agents/skills/nippo/SKILL.md`: Codex 用 skill
+- `.agents/skills/nippo/SKILL.md`: Codex / GitHub Copilot 共通 skill
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nippo
 
-Claude Code / Codex で作業するだけで日報ができる。
+Claude Code / Codex / GitHub Copilot で作業するだけで日報ができる。
 
 ```bash
 # Claude Code
@@ -8,10 +8,13 @@ Claude Code / Codex で作業するだけで日報ができる。
 
 # Codex
 $nippo
+
+# GitHub Copilot CLI
+/nippo
 ```
 
-これだけで、今日やったこと・判断したこと・改善点が `reports/nippo-20XX-YY-ZZ.md` にまとまる。手動で何も記録する必要はない。Claude Code / Codex の作業ログがそのまま日報になる。
-Claude Code では `/nippo`、Codex では `$nippo` で同じ日報生成フローを実行できる。
+これだけで、今日やったこと・判断したこと・改善点が `reports/nippo-20XX-YY-ZZ.md` にまとまる。手動で何も記録する必要はない。各エージェントの作業ログがそのまま日報になる。
+Claude Code と GitHub Copilot では `/nippo`、Codex では `$nippo` で同じ日報生成フローを実行できる。
 
 ---
 
@@ -25,7 +28,7 @@ Claude Code では `/nippo`、Codex では `$nippo` で同じ日報生成フロ�
 ## 今日の作業
 
 - 作業時間帯: 09:14 〜 18:32（ローカルタイムゾーン）
-- ソース: requested all | resolved claude, codex
+- ソース: requested all | resolved claude, codex, copilot
 - プロジェクト: nippo, oitoriaezu-owarasero
 - セッション数: 35
 
@@ -73,9 +76,9 @@ cargo install nippo
 nippo skill install
 ```
 
-これで Claude Code 用の `~/.claude/skills/nippo` と Codex 用の
-`~/.agents/skills/nippo` がセットアップされる。片方だけ入れる場合は
-`--target claude` または `--target codex` を指定する。既存のインストールを
+これで Claude Code 用の `~/.claude/skills/nippo`、Codex 用の
+`~/.agents/skills/nippo`、GitHub Copilot 用の `~/.copilot/skills/nippo` がセットアップされる。
+一つだけ入れる場合は `--target claude`、`--target codex`、`--target copilot` を指定する。既存のインストールを
 置き換える場合は `--force` を付ける。
 
 通常はバイナリに埋め込まれたスキルとテンプレートを書き出す。nippo の
@@ -90,13 +93,13 @@ nippo skill install
 Windows の git checkout ではクレート内の埋め込み用シンボリックリンクが
 通常ファイルになることがあるため、シンボリックリンクを有効にした環境で package を作成する。
 
-**要件**: [Claude Code](https://claude.com/claude-code) または Codex + Rust 1.85+
+**要件**: [Claude Code](https://claude.com/claude-code)、Codex、または GitHub Copilot CLI + Rust 1.88+
 
 ---
 
 ## 全コマンド
 
-Claude Code では `/nippo ...`、Codex では `$nippo ...` を使う。引数と挙動は同じ。
+Claude Code と GitHub Copilot では `/nippo ...`、Codex では `$nippo ...` を使う。引数と挙動は同じ。
 
 ### 日々の記録
 
@@ -172,7 +175,8 @@ CLAUDE.md / AGENTS.md 追記候補として `reports/ledger-export.md` に出力
 /nippo daily                  # /nippo と同じ（日報）
 /nippo daily codex            # Codex 履歴だけで日報
 /nippo daily claude           # Claude Code 履歴だけで日報
-/nippo daily all              # Claude Code + Codex を混ぜて日報
+/nippo daily copilot          # GitHub Copilot CLI 履歴だけで日報
+/nippo daily all              # 利用可能な全ソースを混ぜて日報
 /nippo 3                      # 過去3日分
 /nippo insight 30              # 過去30日分
 /nippo insight 30 nippo        # nippo プロジェクトのみ
@@ -185,7 +189,7 @@ CLAUDE.md / AGENTS.md 追記候補として `reports/ledger-export.md` に出力
 
 ## 定期実行
 
-NIPPO は端末内の Claude Code / Codex の作業履歴を読むため、ローカルファイルへ
+NIPPO は端末内の Claude Code / Codex / GitHub Copilot CLI の作業履歴を読むため、ローカルファイルへ
 アクセスできる定期タスクを使う。クラウド上で動くタスクはローカル履歴を読めない。
 最初に対象プロジェクトで `/nippo daily` または `$nippo daily` を手動実行し、
 `reports/` に日報が作られることを確認しておく。
@@ -235,7 +239,7 @@ CLI セッションを開いたまま一時的に繰り返すだけなら、`/lo
 
 - `reports/` は定期タスクの作業フォルダに作られる。Git worktree を使うと日報もその
   worktree 内に出力されるため、普段使うフォルダへ残したい場合は worktree を無効にする。
-- Claude Code と Codex の両方を使う場合は、どちらか一方で `/nippo daily all` または
+- 複数のエージェントを使う場合は、どれか一つで `/nippo daily all` または
   `$nippo daily all` を定期実行する。同じ日付の日報を両方から作ると、後の実行結果で上書きされる。
 - 定期タスクの指示やスキル展開だけで終わるセッションは、既定のプロンプトノイズ除外の
   対象になる。日報生成時は `--include-prompt-noise` や `--include-self` を付けない。
@@ -251,7 +255,8 @@ nippo collect --period today                     # 今日の JSON 出力
 nippo collect --days 1                           # 今日の JSON 出力（ローカル日付基準）
 nippo collect --days 7 --format summary          # テキストサマリー
 nippo collect --source codex --period today      # Codex 履歴のみ
-nippo collect --source all --days 7              # Claude Code + Codex
+nippo collect --source copilot --period today    # GitHub Copilot CLI 履歴のみ
+nippo collect --source all --days 7              # 利用可能な全ソース
 nippo collect --period last-week                 # 先週
 nippo collect --from 2026-03-01 --to 2026-03-15  # 日付範囲
 nippo collect --project ccswarm                  # プロジェクトフィルタ
@@ -281,7 +286,7 @@ JSON の `meta.period` は、指定した日付範囲の両端と境界の基準
 `--to` だけを指定した場合の開始日は `null` になる。
 
 同じ `session_id` の記録が複数ファイルに分かれている場合は、プロンプトを重複除去して
-1 セッションに統合する。Claude Code / Codex 内から実行したときは、ホストが公開する
+1 セッションに統合する。Claude Code / Codex / GitHub Copilot 内から実行したときは、ホストが公開する
 現在のセッション ID と完全一致する記録を既定で除外する。確認目的で含めたい場合だけ
 `--include-self` を指定する。
 
@@ -364,11 +369,12 @@ JSON の `render_helpers` には、既存の `sessions` と `stats` から機械
 [Rust] nippo collect
     ├─ ~/.claude/projects/**/*.jsonl を rayon で並列パース
     ├─ ~/.codex/history.jsonl + state_5.sqlite + rollout データを収集
+    ├─ ~/.copilot/session-state/*/events.jsonl + workspace.yaml を収集
     ├─ mtime プレフィルタ + 2パスデシリアライズ
     └─ JSON 出力
     │
     ▼
-[Claude] テンプレートに従いレポート生成
+[Agent] テンプレートに従いレポート生成
     │
     ▼
 reports/ に保存
@@ -383,9 +389,10 @@ nippo/
 │   ├── output.rs             # JSON / summary 出力
 │   └── sources/
 │       ├── claude_code.rs    # Claude Code JSONL パーサ
-│       └── codex.rs          # Codex 履歴パーサ
+│       ├── codex.rs          # Codex 履歴パーサ
+│       └── copilot.rs        # GitHub Copilot CLI イベントパーサ
 ├── .agents/skills/nippo/
-│   └── SKILL.md              # Codex 用 skill
+│   └── SKILL.md              # Codex / GitHub Copilot 共通 skill
 ├── .claude/skills/nippo/
 │   ├── SKILL.md              # スキル定義
 │   └── docs -> ../../../docs # テンプレートへのシンボリックリンク

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -2,10 +2,11 @@
 name = "nippo"
 version = "0.1.6"
 edition = "2024"
-description = "Claude Code session collector for daily reports and reflection"
+rust-version = "1.88"
+description = "Claude Code, Codex, and GitHub Copilot session collector for daily reports"
 license = "MIT"
 repository = "https://github.com/nwiizo/nippo"
-keywords = ["claude", "daily-report", "reflection", "productivity"]
+keywords = ["copilot", "daily-report", "reflection", "productivity"]
 categories = ["command-line-utilities"]
 
 [[bin]]

--- a/crates/collector/src/main.rs
+++ b/crates/collector/src/main.rs
@@ -25,6 +25,10 @@ use crate::sources::codex::{
     collect_sessions as collect_codex_sessions,
     discover_history_files as discover_codex_history_files,
 };
+use crate::sources::copilot::{
+    collect_sessions as collect_copilot_sessions,
+    discover_session_files as discover_copilot_session_files,
+};
 
 #[derive(Clone, ValueEnum)]
 enum OutputFormat {
@@ -42,13 +46,15 @@ enum DataSource {
     Claude,
     /// Read Codex history and thread metadata
     Codex,
-    /// Merge Claude Code and Codex history
+    /// Read GitHub Copilot CLI session logs
+    Copilot,
+    /// Merge all available session sources
     All,
 }
 
 #[derive(Subcommand)]
 enum SkillAction {
-    /// Install the nippo skill for Claude Code, Codex, or both
+    /// Install the nippo skill for Claude Code, Codex, GitHub Copilot, or all
     Install {
         /// Skill host to install for
         #[arg(long, value_enum, default_value = "all")]
@@ -64,9 +70,9 @@ enum SkillAction {
 #[command(
     name = "nippo",
     version,
-    about = "Claude Code / Codex session collector for daily reports",
+    about = "Claude Code / Codex / GitHub Copilot session collector for daily reports",
     long_about = "\
-Claude Code / Codex のセッションログを収集・集計するツール。
+Claude Code / Codex / GitHub Copilot のセッションログを収集・集計するツール。
 nippo スキルのデータ収集バックエンドとして動作する。
 
 単体でも使える:
@@ -75,11 +81,12 @@ nippo スキルのデータ収集バックエンドとして動作する。
   nippo collect --period last-week        先週のデータ
   nippo collect --project myapp           プロジェクトで絞り込み
   nippo collect --source codex            Codex 履歴のみ
+  nippo collect --source copilot          GitHub Copilot CLI 履歴のみ
   nippo collect --include-prompt-noise --include-self
                                           除外前の記録を確認
 
 スキルをセットアップする:
-  nippo skill install                     Claude Code + Codex
+  nippo skill install                     Claude Code + Codex + GitHub Copilot
 
 スキルと組み合わせて使う:
   /nippo              日報（事実 + 意思決定 + 用語レビュー）
@@ -102,7 +109,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Collect session data from Claude Code or Codex logs
+    /// Collect session data from Claude Code, Codex, or GitHub Copilot logs
     Collect {
         /// Number of days to look back (0 = all time)
         #[arg(long, default_value = "1")]
@@ -132,7 +139,7 @@ enum Commands {
         #[arg(long)]
         include_prompt_noise: bool,
 
-        /// Include the Claude Code or Codex session running this command
+        /// Include the host agent session running this command
         #[arg(long)]
         include_self: bool,
 
@@ -144,7 +151,7 @@ enum Commands {
         #[arg(long, value_enum, default_value = "json")]
         format: OutputFormat,
 
-        /// Session source (auto/claude/codex/all)
+        /// Session source (auto/claude/codex/copilot/all)
         #[arg(long, value_enum, default_value = "auto")]
         source: DataSource,
 
@@ -155,6 +162,10 @@ enum Commands {
         /// Custom Codex data directory (default: ~/.codex)
         #[arg(long)]
         codex_dir: Option<PathBuf>,
+
+        /// Custom GitHub Copilot data directory (default: ~/.copilot)
+        #[arg(long)]
+        copilot_dir: Option<PathBuf>,
     },
 
     /// Fold structured `## Unclear points` from past reports into a
@@ -216,10 +227,12 @@ fn run() -> Result<()> {
             source,
             claude_dir,
             codex_dir,
+            copilot_dir,
         } => {
             let home_dir = dirs_home();
             let claude_dir = claude_dir.unwrap_or_else(|| home_dir.join(".claude"));
             let codex_dir = codex_dir.unwrap_or_else(|| home_dir.join(".codex"));
+            let copilot_dir = copilot_dir.unwrap_or_else(|| home_dir.join(".copilot"));
 
             // Priority: --period > --from/--to > --days
             let filter = if let Some(ref period) = period {
@@ -230,9 +243,14 @@ fn run() -> Result<()> {
                 DateFilter::from_days(days)
             };
 
-            let selected_sources = resolve_sources(&source, &claude_dir, &codex_dir);
-            let (mut sessions, total_files) =
-                collect_from_sources(&selected_sources, &claude_dir, &codex_dir, &filter)?;
+            let selected_sources = resolve_sources(&source, &claude_dir, &codex_dir, &copilot_dir);
+            let (mut sessions, total_files) = collect_from_sources(
+                &selected_sources,
+                &claude_dir,
+                &codex_dir,
+                &copilot_dir,
+                &filter,
+            )?;
 
             if !include_self {
                 retain_non_current_sessions(&mut sessions, &current_host_session_ids());
@@ -399,11 +417,13 @@ fn resolve_sources(
     source: &DataSource,
     claude_dir: &std::path::Path,
     codex_dir: &std::path::Path,
+    copilot_dir: &std::path::Path,
 ) -> Vec<DataSource> {
     match source {
-        DataSource::Auto => vec![detect_auto_source(claude_dir, codex_dir)],
+        DataSource::Auto => vec![detect_auto_source(claude_dir, codex_dir, copilot_dir)],
         DataSource::Claude => vec![DataSource::Claude],
         DataSource::Codex => vec![DataSource::Codex],
+        DataSource::Copilot => vec![DataSource::Copilot],
         DataSource::All => {
             let mut sources = Vec::new();
             if claude_available(claude_dir) {
@@ -412,15 +432,25 @@ fn resolve_sources(
             if codex_available(codex_dir) {
                 sources.push(DataSource::Codex);
             }
+            if copilot_available(copilot_dir) {
+                sources.push(DataSource::Copilot);
+            }
             if sources.is_empty() {
-                sources.push(detect_auto_source(claude_dir, codex_dir));
+                sources.push(detect_auto_source(claude_dir, codex_dir, copilot_dir));
             }
             sources
         }
     }
 }
 
-fn detect_auto_source(claude_dir: &std::path::Path, codex_dir: &std::path::Path) -> DataSource {
+fn detect_auto_source(
+    claude_dir: &std::path::Path,
+    codex_dir: &std::path::Path,
+    copilot_dir: &std::path::Path,
+) -> DataSource {
+    if std::env::var_os("COPILOT_SESSION_ID").is_some() && copilot_available(copilot_dir) {
+        return DataSource::Copilot;
+    }
     if std::env::var_os("CODEX_THREAD_ID").is_some() && codex_available(codex_dir) {
         return DataSource::Codex;
     }
@@ -430,6 +460,9 @@ fn detect_auto_source(claude_dir: &std::path::Path, codex_dir: &std::path::Path)
     if codex_available(codex_dir) {
         return DataSource::Codex;
     }
+    if copilot_available(copilot_dir) {
+        return DataSource::Copilot;
+    }
     DataSource::Claude
 }
 
@@ -437,6 +470,7 @@ fn collect_from_sources(
     sources: &[DataSource],
     claude_dir: &std::path::Path,
     codex_dir: &std::path::Path,
+    copilot_dir: &std::path::Path,
     filter: &DateFilter,
 ) -> Result<(Vec<RawSession>, usize)> {
     let mut sessions = Vec::new();
@@ -451,6 +485,10 @@ fn collect_from_sources(
             DataSource::Codex => {
                 total_files += discover_codex_history_files(codex_dir)?.len();
                 sessions.extend(collect_codex_sessions(codex_dir, filter)?);
+            }
+            DataSource::Copilot => {
+                total_files += discover_copilot_session_files(copilot_dir)?.len();
+                sessions.extend(collect_copilot_sessions(copilot_dir, filter)?);
             }
             DataSource::Auto | DataSource::All => unreachable!("source must be resolved first"),
         }
@@ -468,11 +506,15 @@ fn retain_non_current_sessions(sessions: &mut Vec<RawSession>, current_ids: &[St
 }
 
 fn current_host_session_ids() -> Vec<String> {
-    ["CLAUDE_CODE_SESSION_ID", "CODEX_THREAD_ID"]
-        .into_iter()
-        .filter_map(|name| std::env::var(name).ok())
-        .filter(|session_id| !session_id.is_empty())
-        .collect()
+    [
+        "CLAUDE_CODE_SESSION_ID",
+        "CODEX_THREAD_ID",
+        "COPILOT_SESSION_ID",
+    ]
+    .into_iter()
+    .filter_map(|name| std::env::var(name).ok())
+    .filter(|session_id| !session_id.is_empty())
+    .collect()
 }
 
 fn claude_available(claude_dir: &std::path::Path) -> bool {
@@ -481,6 +523,10 @@ fn claude_available(claude_dir: &std::path::Path) -> bool {
 
 fn codex_available(codex_dir: &std::path::Path) -> bool {
     codex_dir.join("history.jsonl").exists()
+}
+
+fn copilot_available(copilot_dir: &std::path::Path) -> bool {
+    copilot_dir.join("session-state").is_dir()
 }
 
 fn period_label(period: &Period) -> String {
@@ -501,6 +547,7 @@ fn source_name(source: &DataSource) -> &'static str {
         DataSource::Auto => "auto",
         DataSource::Claude => "claude",
         DataSource::Codex => "codex",
+        DataSource::Copilot => "copilot",
         DataSource::All => "all",
     }
 }
@@ -582,5 +629,29 @@ mod tests {
         };
         assert!(include_prompt_noise);
         assert!(include_self);
+    }
+
+    #[test]
+    fn parses_copilot_source_and_custom_directory() {
+        let cli = Cli::try_parse_from([
+            "nippo",
+            "collect",
+            "--source",
+            "copilot",
+            "--copilot-dir",
+            "/tmp/copilot-home",
+        ])
+        .expect("parse Copilot flags");
+
+        let Commands::Collect {
+            source,
+            copilot_dir,
+            ..
+        } = cli.command
+        else {
+            panic!("expected collect command");
+        };
+        assert!(matches!(source, DataSource::Copilot));
+        assert_eq!(copilot_dir, Some(PathBuf::from("/tmp/copilot-home")));
     }
 }

--- a/crates/collector/src/skill_install.rs
+++ b/crates/collector/src/skill_install.rs
@@ -54,6 +54,7 @@ const SHARED_ASSETS: &[EmbeddedAsset] = &[
 pub(crate) enum SkillTarget {
     Claude,
     Codex,
+    Copilot,
     All,
 }
 
@@ -61,6 +62,7 @@ pub(crate) enum SkillTarget {
 enum SkillKind {
     Claude,
     Codex,
+    Copilot,
 }
 
 #[derive(Clone, Copy)]
@@ -101,7 +103,8 @@ impl SkillTarget {
         match self {
             Self::Claude => &[SkillKind::Claude],
             Self::Codex => &[SkillKind::Codex],
-            Self::All => &[SkillKind::Claude, SkillKind::Codex],
+            Self::Copilot => &[SkillKind::Copilot],
+            Self::All => &[SkillKind::Claude, SkillKind::Codex, SkillKind::Copilot],
         }
     }
 }
@@ -111,6 +114,7 @@ impl SkillKind {
         match self {
             Self::Claude => "Claude Code",
             Self::Codex => "Codex",
+            Self::Copilot => "GitHub Copilot",
         }
     }
 
@@ -118,13 +122,21 @@ impl SkillKind {
         match self {
             Self::Claude => ".claude/skills/nippo",
             Self::Codex => ".agents/skills/nippo",
+            Self::Copilot => ".copilot/skills/nippo",
+        }
+    }
+
+    fn relative_source_path(self) -> &'static str {
+        match self {
+            Self::Claude => ".claude/skills/nippo",
+            Self::Codex | Self::Copilot => ".agents/skills/nippo",
         }
     }
 
     fn skill_contents(self) -> &'static str {
         match self {
             Self::Claude => CLAUDE_SKILL,
-            Self::Codex => CODEX_SKILL,
+            Self::Codex | Self::Copilot => CODEX_SKILL,
         }
     }
 
@@ -132,6 +144,7 @@ impl SkillKind {
         match self {
             Self::Claude => "Claude Code では `/nippo`",
             Self::Codex => "Codex では `$nippo`",
+            Self::Copilot => "GitHub Copilot では `/nippo`",
         }
     }
 }
@@ -176,7 +189,7 @@ pub(crate) fn install(
         let destination = home_dir.join(kind.relative_install_path());
         let source = repo_root
             .as_ref()
-            .map(|root| root.join(kind.relative_install_path()));
+            .map(|root| root.join(kind.relative_source_path()));
         match source.as_deref() {
             Some(source) if !source.is_dir() => {
                 bail!("skill source not found: {}", source.display());
@@ -349,7 +362,7 @@ mod tests {
             "[package]\nversion = \"0.1.4\"\nname = \"nippo\"\n",
         )?;
         for kind in [SkillKind::Claude, SkillKind::Codex] {
-            let source = repo.join(kind.relative_install_path());
+            let source = repo.join(kind.relative_source_path());
             fs::create_dir_all(&source)?;
             fs::write(source.join("SKILL.md"), kind.skill_contents())?;
         }
@@ -376,7 +389,7 @@ mod tests {
 
         install(home.path(), cwd.path(), SkillTarget::All, false)?;
 
-        for kind in [SkillKind::Claude, SkillKind::Codex] {
+        for kind in [SkillKind::Claude, SkillKind::Codex, SkillKind::Copilot] {
             let destination = home.path().join(kind.relative_install_path());
             assert_eq!(
                 fs::read_to_string(destination.join("SKILL.md"))?,
@@ -446,12 +459,12 @@ mod tests {
         install(home.path(), &nested_cwd, SkillTarget::All, false)?;
         install(home.path(), &nested_cwd, SkillTarget::All, false)?;
 
-        for kind in [SkillKind::Claude, SkillKind::Codex] {
+        for kind in [SkillKind::Claude, SkillKind::Codex, SkillKind::Copilot] {
             let destination = home.path().join(kind.relative_install_path());
             assert!(fs::symlink_metadata(&destination)?.file_type().is_symlink());
             assert!(symlink_points_to(
                 &destination,
-                &repo.path().join(kind.relative_install_path())
+                &repo.path().join(kind.relative_source_path())
             )?);
         }
         Ok(())

--- a/crates/collector/src/sources/copilot.rs
+++ b/crates/collector/src/sources/copilot.rs
@@ -1,0 +1,420 @@
+//! GitHub Copilot CLI session collector.
+//!
+//! `~/.copilot/session-state/<session-id>/events.jsonl` is the resumable session
+//! record. Persisted user, assistant, and tool events are normalized into the
+//! source-independent `RawSession` representation used by nippo.
+
+use anyhow::{Context, Result};
+use rayon::prelude::*;
+use serde_json::Value;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::filter::DateFilter;
+use crate::session::{ParsedAssistantEntry, ParsedUserEntry, RawSession};
+
+const MAX_PROMPT_LEN: usize = 500;
+
+#[derive(Debug)]
+pub struct SessionFile {
+    pub path: PathBuf,
+    pub mtime: SystemTime,
+}
+
+#[derive(Default)]
+struct SessionMetadata {
+    session_id: String,
+    cwd: String,
+    git_branch: Option<String>,
+    repository: Option<String>,
+}
+
+pub fn discover_session_files(copilot_dir: &Path) -> Result<Vec<SessionFile>> {
+    let session_state_dir = copilot_dir.join("session-state");
+    if !session_state_dir.is_dir() {
+        anyhow::bail!(
+            "GitHub Copilot CLI の履歴データが見つかりません: {}\n\n\
+             Copilot CLI のセッションは session-state/<session-id>/events.jsonl に保存されます。\n\
+             カスタムディレクトリを指定する場合は --copilot-dir オプションを使用してください。",
+            session_state_dir.display()
+        );
+    }
+
+    let mut files = Vec::new();
+    for entry in fs::read_dir(&session_state_dir)
+        .with_context(|| format!("Failed to read {}", session_state_dir.display()))?
+    {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let path = entry.path().join("events.jsonl");
+        let metadata = match fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => metadata,
+            _ => continue,
+        };
+        files.push(SessionFile {
+            path,
+            mtime: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+        });
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(files)
+}
+
+fn truncate(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        text.to_string()
+    } else {
+        format!("{}...", text.chars().take(max).collect::<String>())
+    }
+}
+
+fn extract_project(metadata: &SessionMetadata) -> String {
+    if !metadata.cwd.is_empty() {
+        return Path::new(&metadata.cwd)
+            .file_name()
+            .map(|value| value.to_string_lossy().to_string())
+            .unwrap_or_else(|| metadata.cwd.clone());
+    }
+    metadata
+        .repository
+        .as_deref()
+        .and_then(|repository| repository.rsplit('/').next())
+        .filter(|project| !project.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn yaml_string(value: &serde_yaml::Value, keys: &[&str]) -> Option<String> {
+    match value {
+        serde_yaml::Value::Mapping(mapping) => {
+            for key in keys {
+                if let Some(value) = mapping.get(serde_yaml::Value::String((*key).to_string()))
+                    && let Some(value) = value.as_str()
+                    && !value.is_empty()
+                {
+                    return Some(value.to_string());
+                }
+            }
+            mapping.values().find_map(|value| yaml_string(value, keys))
+        }
+        serde_yaml::Value::Sequence(values) => {
+            values.iter().find_map(|value| yaml_string(value, keys))
+        }
+        _ => None,
+    }
+}
+
+fn load_workspace_metadata(session_dir: &Path) -> SessionMetadata {
+    let path = session_dir.join("workspace.yaml");
+    let Ok(contents) = fs::read_to_string(path) else {
+        return SessionMetadata::default();
+    };
+    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&contents) else {
+        return SessionMetadata::default();
+    };
+
+    SessionMetadata {
+        cwd: yaml_string(&value, &["cwd", "workingDirectory", "gitRoot"]).unwrap_or_default(),
+        git_branch: yaml_string(&value, &["branch", "gitBranch"]),
+        repository: yaml_string(&value, &["repository"]),
+        ..SessionMetadata::default()
+    }
+}
+
+fn update_context(metadata: &mut SessionMetadata, context: &Value) {
+    if let Some(cwd) = context
+        .get("cwd")
+        .or_else(|| context.get("gitRoot"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        metadata.cwd = cwd.to_string();
+    }
+    if let Some(branch) = context
+        .get("branch")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        metadata.git_branch = Some(branch.to_string());
+    }
+    if let Some(repository) = context
+        .get("repository")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        metadata.repository = Some(repository.to_string());
+    }
+}
+
+fn extract_argument_paths(arguments: &Value) -> Vec<String> {
+    const PATH_KEYS: &[&str] = &["fileName", "file_path", "path", "paths", "possiblePaths"];
+
+    fn visit(value: &Value, current_key: Option<&str>, paths: &mut Vec<String>) {
+        match value {
+            Value::String(value)
+                if current_key.is_some_and(|key| PATH_KEYS.contains(&key)) && !value.is_empty() =>
+            {
+                paths.push(value.clone());
+            }
+            Value::Array(values) if current_key.is_some_and(|key| PATH_KEYS.contains(&key)) => {
+                for value in values {
+                    if let Some(value) = value.as_str()
+                        && !value.is_empty()
+                    {
+                        paths.push(value.to_string());
+                    }
+                }
+            }
+            Value::Object(object) => {
+                for (key, value) in object {
+                    visit(value, Some(key), paths);
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    visit(value, current_key, paths);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut paths = Vec::new();
+    visit(arguments, None, &mut paths);
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+pub fn parse_session_file(path: &Path, filter: &DateFilter) -> Result<Option<RawSession>> {
+    let file = File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let session_dir = path.parent().unwrap_or_else(|| Path::new(""));
+    let mut metadata = load_workspace_metadata(session_dir);
+    metadata.session_id = session_dir
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let mut user_entries = Vec::new();
+    let mut assistant_entries = Vec::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(line) if !line.trim().is_empty() => line,
+            _ => continue,
+        };
+        let event: Value = match serde_json::from_str(&line) {
+            Ok(event) => event,
+            Err(_) => continue,
+        };
+        let event_type = event.get("type").and_then(Value::as_str).unwrap_or("");
+        let data = event.get("data").unwrap_or(&Value::Null);
+
+        // Sub-agent events share the parent stream. Like Claude sidechains,
+        // they are excluded to avoid double-counting delegated work or letting
+        // a sub-agent context overwrite the parent session metadata.
+        if event.get("agentId").and_then(Value::as_str).is_some() {
+            continue;
+        }
+
+        match event_type {
+            "session.start" => {
+                if let Some(session_id) = data
+                    .get("sessionId")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                {
+                    metadata.session_id = session_id.to_string();
+                }
+                if let Some(context) = data.get("context") {
+                    update_context(&mut metadata, context);
+                }
+            }
+            "session.context_changed" => update_context(&mut metadata, data),
+            _ => {}
+        }
+
+        let Some(timestamp) = event.get("timestamp").and_then(Value::as_str) else {
+            continue;
+        };
+        if !filter.matches(timestamp) {
+            continue;
+        }
+
+        match event_type {
+            "user.message" => {
+                if let Some(content) = data
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|content| !content.is_empty())
+                {
+                    user_entries.push(ParsedUserEntry {
+                        timestamp: timestamp.to_string(),
+                        text: truncate(content, MAX_PROMPT_LEN),
+                    });
+                }
+            }
+            "assistant.message" => {
+                assistant_entries.push(ParsedAssistantEntry {
+                    timestamp: timestamp.to_string(),
+                    message_count: 1,
+                    tool_uses: Vec::new(),
+                    input_tokens: 0,
+                    output_tokens: data
+                        .get("outputTokens")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0),
+                    file_paths: Vec::new(),
+                });
+            }
+            "assistant.usage" => {
+                let input_tokens = data.get("inputTokens").and_then(Value::as_u64).unwrap_or(0);
+                if input_tokens > 0 {
+                    assistant_entries.push(ParsedAssistantEntry {
+                        timestamp: timestamp.to_string(),
+                        message_count: 0,
+                        tool_uses: Vec::new(),
+                        input_tokens,
+                        output_tokens: 0,
+                        file_paths: Vec::new(),
+                    });
+                }
+            }
+            "tool.execution_start" => {
+                if let Some(tool_name) = data
+                    .get("toolName")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                {
+                    assistant_entries.push(ParsedAssistantEntry {
+                        timestamp: timestamp.to_string(),
+                        message_count: 0,
+                        tool_uses: vec![tool_name.to_string()],
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        file_paths: data
+                            .get("arguments")
+                            .map(extract_argument_paths)
+                            .unwrap_or_default(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if user_entries.is_empty() && assistant_entries.is_empty() {
+        return Ok(None);
+    }
+
+    user_entries.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+    assistant_entries.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+    let project = extract_project(&metadata);
+
+    Ok(Some(RawSession {
+        session_id: metadata.session_id,
+        project,
+        project_path: metadata.cwd,
+        git_branch: metadata.git_branch,
+        user_entries,
+        assistant_entries,
+    }))
+}
+
+pub fn collect_sessions(copilot_dir: &Path, filter: &DateFilter) -> Result<Vec<RawSession>> {
+    let files = discover_session_files(copilot_dir)?;
+    let cutoff = filter.mtime_cutoff();
+    let candidates: Vec<&SessionFile> = files
+        .iter()
+        .filter(|file| cutoff.map(|cutoff| file.mtime >= cutoff).unwrap_or(true))
+        .collect();
+
+    Ok(candidates
+        .par_iter()
+        .filter_map(|file| parse_session_file(&file.path, filter).ok().flatten())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::summarize_session;
+    use tempfile::tempdir;
+
+    fn all_time_filter() -> DateFilter {
+        DateFilter::from_days(0)
+    }
+
+    #[test]
+    fn collects_copilot_events_and_workspace_metadata() -> Result<()> {
+        let dir = tempdir().context("tempdir")?;
+        let session_dir = dir.path().join("session-state/session-1");
+        fs::create_dir_all(&session_dir)?;
+        fs::write(
+            session_dir.join("workspace.yaml"),
+            "workspace:\n  cwd: /tmp/nippo\n  branch: feat/copilot\n",
+        )?;
+        fs::write(
+            session_dir.join("events.jsonl"),
+            concat!(
+                "{\"type\":\"session.start\",\"timestamp\":\"2026-08-24T01:00:00Z\",\"data\":{\"sessionId\":\"session-1\",\"context\":{\"cwd\":\"/tmp/nippo\",\"branch\":\"feat/copilot\"}}}\n",
+                "{\"type\":\"user.message\",\"timestamp\":\"2026-08-24T01:01:00Z\",\"data\":{\"content\":\"Add Copilot support\"}}\n",
+                "{\"type\":\"assistant.message\",\"timestamp\":\"2026-08-24T01:02:00Z\",\"data\":{\"content\":\"Working on it\",\"outputTokens\":12}}\n",
+                "{\"type\":\"assistant.usage\",\"timestamp\":\"2026-08-24T01:02:01Z\",\"data\":{\"inputTokens\":30,\"outputTokens\":12}}\n",
+                "{\"type\":\"tool.execution_start\",\"timestamp\":\"2026-08-24T01:03:00Z\",\"data\":{\"toolName\":\"edit\",\"arguments\":{\"fileName\":\"/tmp/nippo/src/main.rs\"}}}\n",
+                "{\"type\":\"session.context_changed\",\"timestamp\":\"2026-08-24T01:03:30Z\",\"agentId\":\"subagent-1\",\"data\":{\"cwd\":\"/tmp/wrong-subagent-project\",\"branch\":\"feat/subagent\"}}\n",
+                "{\"type\":\"assistant.message\",\"timestamp\":\"2026-08-24T01:04:00Z\",\"agentId\":\"subagent-1\",\"data\":{\"content\":\"delegated\",\"outputTokens\":99}}\n"
+            ),
+        )?;
+
+        let sessions = collect_sessions(dir.path(), &all_time_filter())?;
+        assert_eq!(sessions.len(), 1);
+        let summary = summarize_session(&sessions[0]);
+        assert_eq!(summary.session_id, "session-1");
+        assert_eq!(summary.project, "nippo");
+        assert_eq!(summary.project_path, "/tmp/nippo");
+        assert_eq!(summary.git_branch.as_deref(), Some("feat/copilot"));
+        assert_eq!(summary.message_counts.user, 1);
+        assert_eq!(summary.message_counts.assistant, 1);
+        assert_eq!(summary.tool_usage.get("edit"), Some(&1));
+        assert_eq!(summary.total_input_tokens, 30);
+        assert_eq!(summary.total_output_tokens, 12);
+        assert_eq!(summary.files_touched, vec!["src/main.rs"]);
+        Ok(())
+    }
+
+    #[test]
+    fn filters_events_by_local_date_range() -> Result<()> {
+        let dir = tempdir().context("tempdir")?;
+        let session_dir = dir.path().join("session-state/session-2");
+        fs::create_dir_all(&session_dir)?;
+        fs::write(
+            session_dir.join("events.jsonl"),
+            concat!(
+                "{\"type\":\"session.start\",\"timestamp\":\"2026-08-20T00:00:00Z\",\"data\":{\"context\":{\"repository\":\"owner/project\"}}}\n",
+                "{\"type\":\"user.message\",\"timestamp\":\"2026-08-20T00:01:00Z\",\"data\":{\"content\":\"old\"}}\n",
+                "{\"type\":\"user.message\",\"timestamp\":\"2026-08-24T00:01:00Z\",\"data\":{\"content\":\"current\"}}\n"
+            ),
+        )?;
+
+        let filter = DateFilter::from_range(Some("2026-08-24"), Some("2026-08-24"))?;
+        let sessions = collect_sessions(dir.path(), &filter)?;
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].project, "project");
+        assert_eq!(sessions[0].user_entries.len(), 1);
+        assert_eq!(sessions[0].user_entries[0].text, "current");
+        Ok(())
+    }
+
+    #[test]
+    fn discovery_requires_session_state_directory() {
+        let dir = tempdir().expect("tempdir");
+        let error = discover_session_files(dir.path()).expect_err("missing data must fail");
+        assert!(error.to_string().contains("session-state"));
+    }
+}

--- a/crates/collector/src/sources/mod.rs
+++ b/crates/collector/src/sources/mod.rs
@@ -1,2 +1,3 @@
 pub mod claude_code;
 pub mod codex;
+pub mod copilot;

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,6 +1,6 @@
 # データソース仕様
 
-Claude Code / Codex のセッションデータの保存場所と形式。
+Claude Code / Codex / GitHub Copilot CLI のセッションデータの保存場所と形式。
 
 ## 保存場所
 
@@ -121,6 +121,36 @@ SELECT id, cwd, git_branch, rollout_path FROM threads;
 - `git_branch`: ブランチ名
 - `rollout_path`: assistant 側の rollout JSONL へのパス
 
+## GitHub Copilot CLI の保存場所
+
+```
+~/.copilot/session-state/{session-id}/events.jsonl
+~/.copilot/session-state/{session-id}/workspace.yaml
+```
+
+- `events.jsonl`: セッション再開に使われる完全なイベントログ。`nippo` の主データソース
+- `workspace.yaml`: `cwd` / `branch` / `repository` のメタデータ補完
+- `session-store.db`: 横断検索用インデックス。`nippo` では主データソースに使わない
+
+### Copilot イベント（収集対象）
+
+| type | 用途 | nippo での扱い |
+|------|------|---------------|
+| `session.start` | session ID と workspace context | メタデータとして使用 |
+| `session.context_changed` | cwd / repository / branch の変更 | メタデータとして使用 |
+| `user.message` | ユーザーメッセージ | **収集対象** |
+| `assistant.message` | 完成したアシスタント応答 | **収集対象** |
+| `assistant.usage` | API 呼び出しの token 使用量 | 保存されている場合のみ input token を収集 |
+| `tool.execution_start` | 実行されたツールと引数 | **収集対象** |
+| その他 | reasoning、進捗、権限、tool result 等 | スキップ |
+
+全イベント共通の `timestamp` は ISO 8601。`data.content`、`data.toolName`、
+`data.arguments` など、イベント型ごとの確定フィールドだけを読む。`agentId` がある
+サブエージェントイベントは、Claude Code の sidechain と同様に二重集計を避けるため除外する。
+
+Copilot の永続ログでは ephemeral な `assistant.usage` が存在しないことがある。
+その場合、`assistant.message.data.outputTokens` は集計できるが input token は 0 のままになる。
+
 ## コレクター CLI オプション
 
 ```bash
@@ -136,12 +166,13 @@ nippo collect [OPTIONS]
 | `--project NAME` | プロジェクト名でフィルタ（部分一致） | なし |
 | `--stats-only` | セッション詳細を省略し統計のみ出力 | `false` |
 | `--include-prompt-noise` | 定型通知・画像プレースホルダ・短い肯定応答なども含める | `false` |
-| `--include-self` | コマンドを実行している Claude Code / Codex セッションも含める | `false` |
+| `--include-self` | コマンドを実行しているホストエージェントのセッションも含める | `false` |
 | `--max-sessions N` | 出力するセッション数の上限（0 = 無制限） | `0` |
 | `--format json\|summary` | 出力形式 | `json` |
-| `--source auto\|claude\|codex\|all` | データソース選択 | `auto` |
+| `--source auto\|claude\|codex\|copilot\|all` | データソース選択 | `auto` |
 | `--claude-dir PATH` | Claude データディレクトリ | `~/.claude` |
 | `--codex-dir PATH` | Codex データディレクトリ | `~/.codex` |
+| `--copilot-dir PATH` | GitHub Copilot データディレクトリ | `~/.copilot` |
 
 `--period` の値: `today`, `yesterday`, `this-week`, `last-week`, `week-before-last`, `this-month`, `last-month`, `month-before-last`
 
@@ -166,7 +197,7 @@ compact の導入文、短い肯定応答を user エントリから除外する
 一致する重複を除外してから、メッセージ・ツール使用・トークンを合算する。
 `--max-sessions` は統合後のセッションを最新順に並べてから適用する。
 
-`CLAUDE_CODE_SESSION_ID` または `CODEX_THREAD_ID` が設定されている場合、その値と
+`CLAUDE_CODE_SESSION_ID`、`CODEX_THREAD_ID`、`COPILOT_SESSION_ID` のいずれかが設定されている場合、その値と
 完全一致するセッションは既定で除外する。時刻やメッセージ数を使った推測では除外しない。
 
 JSON の `render_helpers` はローカル時刻のセッション範囲、30 分未満の間隔でつながる
@@ -175,7 +206,9 @@ JSON の `render_helpers` はローカル時刻のセッション範囲、30 分
 
 `--source auto` の判定:
 
+- `COPILOT_SESSION_ID` があり Copilot データもあるときは `copilot`
 - `CODEX_THREAD_ID` があるときは `codex`
 - それ以外は Claude Code のデータがあれば `claude`
 - Claude がなく Codex があれば `codex`
-- 明示的に両方混ぜたいときだけ `--source all`
+- Claude と Codex がなく Copilot があれば `copilot`
+- 利用可能なソースをすべて混ぜたいときは `--source all`


### PR DESCRIPTION
## Summary

- collect GitHub Copilot CLI events from ~/.copilot/session-state
- add copilot source selection, auto-detection, and custom data directory support
- install the nippo skill into ~/.copilot/skills/nippo and document the workflow
- exclude sub-agent events and preserve workspace metadata from event context or workspace.yaml
- raise MSRV to Rust 1.88 because the existing codebase uses stabilized let chains

## Validation

- cargo test --all-features (56 passed)
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --release
- cargo package --locked --no-verify
- CLI smoke with an empty Copilot session-state directory

The Copilot parser is covered with synthetic persisted event fixtures, including sub-agent exclusion and date filtering. No real Copilot CLI session-state fixture was available on the development machine, so real-session compatibility remains to be confirmed against user data.