### PR TITLE
feat(collector): add opencode source (SQLite reader)

### DIFF
--- a/.agents/skills/nippo/SKILL.md
+++ b/.agents/skills/nippo/SKILL.md
@@ -12,7 +12,7 @@ Use this skill when the user wants to turn recent Claude Code or Codex work into
 - mode: default, `daily`, `brief`, `reflection`, `guide`, `report`, `review`, `insight`, `trend`, `plan`, `ledger`
 - optional days
 - optional project filter
-- optional source override: `claude`, `codex`, `all`
+- optional source override: `claude`, `codex`, `opencode`, `all`
 
 Examples:
 
@@ -28,7 +28,7 @@ Examples:
 2. Otherwise prefer `nippo collect ...` when `nippo` is already installed.
 3. If neither is available, stop and tell the user to install `nippo`.
 4. Treat `daily` as an alias of the default daily report mode.
-5. Default to `--source auto`. Override when the user explicitly asks for `claude`, `codex`, or `all`. The collector removes deterministic prompt noise by default; do not pass `--include-prompt-noise` during report generation.
+5. Default to `--source auto`. Override when the user explicitly asks for `claude`, `codex`, `opencode`, or `all`. The collector removes deterministic prompt noise by default; do not pass `--include-prompt-noise` during report generation.
 6. For `brief`, save the summary output directly and stop.
 7. For `ledger`, do NOT call `nippo collect`. Run `nippo ledger` (or `cargo run -q -p nippo -- ledger`) which scans `reports/nippo-*.md` (daily reports) for the `## Unclear points` section, folds them into `reports/ledger.yaml`, and prints a CONVERGED / DIVERGENCE-SIGNAL / CONTINUE verdict. Relay that verdict back to the user verbatim; do not over-interpret. If the user asks for agent-config candidates, run `nippo ledger --export`: it writes recurring General Fix Rules to `reports/ledger-export.md`. Tell the user these are candidates only — a human must curate them before copying anything into CLAUDE.md / AGENTS.md.
 8. For `plan`, do NOT call `nippo collect`. Find the newest `reports/nippo-*.md` by the date in its filename and read it. Also read `reports/ledger.yaml` if present and use unresolved recurring General Fix Rules as candidate material. Read [docs/templates/plan-template.md](docs/templates/plan-template.md) and [docs/reflection-theory.md](docs/reflection-theory.md), present only 1-3 experiment candidates, leave the choice / reason / first-step fields blank for the user, save to `reports/plan-YYYY-MM-DD.md`, and report the path.
@@ -72,7 +72,7 @@ Examples:
 - For `reflection` and `guide`, also read the same-day `reports/nippo-YYYY-MM-DD.md` if it exists.
 - If the first token is neither a mode name, a number, nor a source selector, treat it as a project filter and run the default daily mode with `--project`.
 - Date boundaries follow the machine's local timezone. `--days 1` and `daily` mean the current local calendar day.
-- Treat one token matching `claude`, `codex`, or `all` as the source selector and pass it through to `--source`.
+- Treat one token matching `claude`, `codex`, `opencode`, or `all` as the source selector and pass it through to `--source`.
 - `Codex` report data comes from `history.jsonl`, `state_5.sqlite`, and rollout data referenced by `rollout_path`. Treat `logs_2.sqlite` as diagnostics only.
 - Codex-derived reports may have sparse assistant/tool metrics. State that explicitly instead of inventing numbers.
 - For daily reports, copy `meta.source`, `meta.total_sessions`, `stats.projects_worked_on`, and `stats.tool_frequency` from the collected JSON instead of inferring them from an older report.

--- a/.claude/skills/nippo/SKILL.md
+++ b/.claude/skills/nippo/SKILL.md
@@ -62,7 +62,7 @@ context: fork
 
 `daily` は `(空)` と同じ日報モードのエイリアス。出力ファイル名は `reports/nippo-YYYY-MM-DD.md` を使う。
 
-残りトークンのうち `claude` / `codex` / `all` は `--source` に渡す。数値があれば `--days` を置換。それ以外の文字列は `--project` に渡す。先頭単語がモード名・数値・source のいずれでもない場合は日報モードとして扱い、その単語を `--project` に渡す。
+残りトークンのうち `claude` / `codex` / `opencode` / `all` は `--source` に渡す。数値があれば `--days` を置換。それ以外の文字列は `--project` に渡す。先頭単語がモード名・数値・source のいずれでもない場合は日報モードとして扱い、その単語を `--project` に渡す。
 
 ## 収集と生成
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ skill を介さず、collector の結果を直接確認することもできま�
 nippo collect --period today
 nippo collect --days 7 --format summary
 nippo collect --source codex --period today
+nippo collect --source opencode --period today
 nippo collect --source all --days 7
 nippo collect --period last-week
 nippo collect --from 2026-08-01 --to 2026-08-31

--- a/crates/collector/src/main.rs
+++ b/crates/collector/src/main.rs
@@ -26,6 +26,10 @@ use crate::sources::codex::{
     collect_sessions as collect_codex_sessions,
     discover_history_files as discover_codex_history_files,
 };
+use crate::sources::opencode::{
+    collect_sessions as collect_opencode_sessions,
+    discover_history_files as discover_opencode_history_files,
+};
 
 #[derive(Clone, ValueEnum)]
 enum OutputFormat {
@@ -43,7 +47,9 @@ enum DataSource {
     Claude,
     /// Read Codex history and thread metadata
     Codex,
-    /// Merge Claude Code and Codex history
+    /// Read opencode SQLite history (~/.local/share/opencode)
+    Opencode,
+    /// Merge Claude Code, Codex, and opencode history
     All,
 }
 
@@ -156,6 +162,10 @@ enum Commands {
         /// Custom Codex data directory (default: ~/.codex)
         #[arg(long)]
         codex_dir: Option<PathBuf>,
+
+        /// Custom opencode data directory (default: ~/.local/share/opencode)
+        #[arg(long)]
+        opencode_dir: Option<PathBuf>,
     },
 
     /// Fold structured `## Unclear points` from past reports into a
@@ -217,10 +227,13 @@ fn run() -> Result<()> {
             source,
             claude_dir,
             codex_dir,
+            opencode_dir,
         } => {
             let home_dir = dirs_home();
             let claude_dir = claude_dir.unwrap_or_else(|| home_dir.join(".claude"));
             let codex_dir = codex_dir.unwrap_or_else(|| home_dir.join(".codex"));
+            let opencode_dir =
+                opencode_dir.unwrap_or_else(|| home_dir.join(".local/share/opencode"));
 
             // Priority: --period > --from/--to > --days
             let filter = if let Some(ref period) = period {
@@ -231,9 +244,14 @@ fn run() -> Result<()> {
                 DateFilter::from_days(days)
             };
 
-            let selected_sources = resolve_sources(&source, &claude_dir, &codex_dir);
-            let (mut sessions, total_files) =
-                collect_from_sources(&selected_sources, &claude_dir, &codex_dir, &filter)?;
+            let selected_sources = resolve_sources(&source, &claude_dir, &codex_dir, &opencode_dir);
+            let (mut sessions, total_files) = collect_from_sources(
+                &selected_sources,
+                &claude_dir,
+                &codex_dir,
+                &opencode_dir,
+                &filter,
+            )?;
 
             if !include_self {
                 retain_non_current_sessions(&mut sessions, &current_host_session_ids());
@@ -400,11 +418,13 @@ fn resolve_sources(
     source: &DataSource,
     claude_dir: &std::path::Path,
     codex_dir: &std::path::Path,
+    opencode_dir: &std::path::Path,
 ) -> Vec<DataSource> {
     match source {
-        DataSource::Auto => vec![detect_auto_source(claude_dir, codex_dir)],
+        DataSource::Auto => vec![detect_auto_source(claude_dir, codex_dir, opencode_dir)],
         DataSource::Claude => vec![DataSource::Claude],
         DataSource::Codex => vec![DataSource::Codex],
+        DataSource::Opencode => vec![DataSource::Opencode],
         DataSource::All => {
             let mut sources = Vec::new();
             if claude_available(claude_dir) {
@@ -413,15 +433,22 @@ fn resolve_sources(
             if codex_available(codex_dir) {
                 sources.push(DataSource::Codex);
             }
+            if opencode_available(opencode_dir) {
+                sources.push(DataSource::Opencode);
+            }
             if sources.is_empty() {
-                sources.push(detect_auto_source(claude_dir, codex_dir));
+                sources.push(detect_auto_source(claude_dir, codex_dir, opencode_dir));
             }
             sources
         }
     }
 }
 
-fn detect_auto_source(claude_dir: &std::path::Path, codex_dir: &std::path::Path) -> DataSource {
+fn detect_auto_source(
+    claude_dir: &std::path::Path,
+    codex_dir: &std::path::Path,
+    opencode_dir: &std::path::Path,
+) -> DataSource {
     if std::env::var_os("CODEX_THREAD_ID").is_some() && codex_available(codex_dir) {
         return DataSource::Codex;
     }
@@ -431,6 +458,9 @@ fn detect_auto_source(claude_dir: &std::path::Path, codex_dir: &std::path::Path)
     if codex_available(codex_dir) {
         return DataSource::Codex;
     }
+    if opencode_available(opencode_dir) {
+        return DataSource::Opencode;
+    }
     DataSource::Claude
 }
 
@@ -438,6 +468,7 @@ fn collect_from_sources(
     sources: &[DataSource],
     claude_dir: &std::path::Path,
     codex_dir: &std::path::Path,
+    opencode_dir: &std::path::Path,
     filter: &DateFilter,
 ) -> Result<(Vec<RawSession>, usize)> {
     let mut sessions = Vec::new();
@@ -452,6 +483,10 @@ fn collect_from_sources(
             DataSource::Codex => {
                 total_files += discover_codex_history_files(codex_dir)?.len();
                 sessions.extend(collect_codex_sessions(codex_dir, filter)?);
+            }
+            DataSource::Opencode => {
+                total_files += discover_opencode_history_files(opencode_dir)?.len();
+                sessions.extend(collect_opencode_sessions(opencode_dir, filter)?);
             }
             DataSource::Auto | DataSource::All => unreachable!("source must be resolved first"),
         }
@@ -484,6 +519,10 @@ fn codex_available(codex_dir: &std::path::Path) -> bool {
     codex_dir.join("history.jsonl").exists()
 }
 
+fn opencode_available(opencode_dir: &std::path::Path) -> bool {
+    opencode_dir.join("opencode.db").exists() || opencode_dir.join("opencode-dev.db").exists()
+}
+
 fn period_label(period: &Period) -> String {
     match period {
         Period::Today => "today".to_string(),
@@ -502,6 +541,7 @@ fn source_name(source: &DataSource) -> &'static str {
         DataSource::Auto => "auto",
         DataSource::Claude => "claude",
         DataSource::Codex => "codex",
+        DataSource::Opencode => "opencode",
         DataSource::All => "all",
     }
 }

--- a/crates/collector/src/sources/mod.rs
+++ b/crates/collector/src/sources/mod.rs
@@ -1,2 +1,3 @@
 pub mod claude_code;
 pub mod codex;
+pub mod opencode;

--- a/crates/collector/src/sources/opencode.rs
+++ b/crates/collector/src/sources/opencode.rs
@@ -138,17 +138,23 @@ fn collect_from_db(db_path: &Path, filter: &DateFilter) -> Result<Vec<RawSession
                         MessageIndexEntry {
                             session_id,
                             role: MessageRole::Assistant { entry_index },
-                            timestamp,
                         },
                     );
                 }
                 "user" => {
+                    let session = sessions
+                        .get_mut(&session_id)
+                        .expect("session was validated above");
+                    let entry_index = session.user_entries.len();
+                    session.user_entries.push(ParsedUserEntry {
+                        timestamp,
+                        text: String::new(),
+                    });
                     message_index.insert(
                         message_id,
                         MessageIndexEntry {
                             session_id,
-                            role: MessageRole::User,
-                            timestamp,
+                            role: MessageRole::User { entry_index },
                         },
                     );
                 }
@@ -190,14 +196,27 @@ fn collect_from_db(db_path: &Path, filter: &DateFilter) -> Result<Vec<RawSession
             let part_type = data.get("type").and_then(Value::as_str).unwrap_or("");
 
             match (&index_entry.role, part_type) {
-                (MessageRole::User, "text") => {
+                (MessageRole::User { entry_index }, "text") => {
+                    let is_synthetic = data
+                        .get("synthetic")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    let is_ignored = data
+                        .get("ignored")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    if is_synthetic || is_ignored {
+                        continue;
+                    }
                     if let Some(text) = data.get("text").and_then(Value::as_str) {
                         let trimmed = text.trim();
-                        if !trimmed.is_empty() {
-                            session.user_entries.push(ParsedUserEntry {
-                                timestamp: index_entry.timestamp.clone(),
-                                text: truncate(trimmed, MAX_PROMPT_LEN),
-                            });
+                        if !trimmed.is_empty()
+                            && let Some(entry) = session.user_entries.get_mut(*entry_index)
+                        {
+                            if !entry.text.is_empty() {
+                                entry.text.push('\n');
+                            }
+                            entry.text.push_str(trimmed);
                         }
                     }
                 }
@@ -223,6 +242,12 @@ fn collect_from_db(db_path: &Path, filter: &DateFilter) -> Result<Vec<RawSession
 
     let mut sessions: Vec<RawSession> = sessions.into_values().collect();
     for session in &mut sessions {
+        session
+            .user_entries
+            .retain(|entry| !entry.text.trim().is_empty());
+        for entry in &mut session.user_entries {
+            entry.text = truncate(entry.text.trim(), MAX_PROMPT_LEN);
+        }
         session
             .user_entries
             .sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
@@ -260,11 +285,10 @@ struct SessionMeta {
 struct MessageIndexEntry {
     session_id: String,
     role: MessageRole,
-    timestamp: String,
 }
 
 enum MessageRole {
-    User,
+    User { entry_index: usize },
     Assistant { entry_index: usize },
 }
 
@@ -799,6 +823,74 @@ mod tests {
         let session = &sessions[0];
         assert_eq!(session.user_entries.len(), 1);
         assert_eq!(session.user_entries[0].text, "real user");
+    }
+
+    #[test]
+    fn skips_synthetic_and_ignored_user_text_parts() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("opencode.db");
+        write_db(&db_path);
+        let conn = Connection::open(&db_path).expect("open");
+
+        for (message_id, part_id, timestamp, flag) in [
+            (
+                "msg-synthetic",
+                "part-synthetic",
+                1_776_144_300_000_i64,
+                r#""synthetic":true"#,
+            ),
+            (
+                "msg-ignored",
+                "part-ignored",
+                1_776_144_400_000_i64,
+                r#""ignored":true"#,
+            ),
+        ] {
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+                (message_id, "ses-1", timestamp, r#"{"role":"user"}"#),
+            )
+            .expect("insert user message");
+            let data = format!(r#"{{"type":"text","text":"internal context",{flag}}}"#);
+            conn.execute(
+                "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+                (part_id, message_id, "ses-1", timestamp, data),
+            )
+            .expect("insert user text part");
+        }
+
+        let filter = DateFilter::from_days(0);
+        let sessions = collect_sessions(dir.path(), &filter).expect("collect");
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].user_entries.len(), 1);
+        assert_eq!(sessions[0].user_entries[0].text, "最初の指示");
+    }
+
+    #[test]
+    fn joins_user_text_parts_into_one_message() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("opencode.db");
+        write_db(&db_path);
+        let conn = Connection::open(&db_path).expect("open");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-u2",
+                "msg-u",
+                "ses-1",
+                1_776_144_000_001_i64,
+                r#"{"type":"text","text":"次の指示"}"#,
+            ),
+        )
+        .expect("insert second user text part");
+
+        let filter = DateFilter::from_days(0);
+        let sessions = collect_sessions(dir.path(), &filter).expect("collect");
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].user_entries.len(), 1);
+        assert_eq!(sessions[0].user_entries[0].text, "最初の指示\n次の指示");
     }
 
     #[test]

--- a/crates/collector/src/sources/opencode.rs
+++ b/crates/collector/src/sources/opencode.rs
@@ -1,0 +1,810 @@
+//! opencode 履歴のコレクター。
+//!
+//! `~/.local/share/opencode/opencode.db` の SQLite (`session` / `message` /
+//! `part` / `project` テーブル) から、日報生成に必要なセッション一覧へ変換する。
+//! opencode は生の JSON を part.data に格納するため、tool 使用と file path は
+//! `type=tool` の part を解釈して抽出する。
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::filter::DateFilter;
+use crate::session::{ParsedAssistantEntry, ParsedUserEntry, RawSession};
+
+const MAX_PROMPT_LEN: usize = 500;
+
+/// opencode が使う可能性のある DB ファイル名を優先度順に並べる。
+/// prod は `opencode.db`、dev build は `opencode-dev.db`。
+const DB_CANDIDATES: &[&str] = &["opencode.db", "opencode-dev.db"];
+
+pub fn discover_history_files(opencode_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files: Vec<PathBuf> = DB_CANDIDATES
+        .iter()
+        .map(|name| opencode_dir.join(name))
+        .filter(|path| path.exists())
+        .collect();
+
+    if files.is_empty() {
+        anyhow::bail!(
+            "opencode の履歴データが見つかりません: {}\n\n\
+             opencode を使用すると、セッションは opencode.db (または opencode-dev.db)\n\
+             の SQLite に保存されます。\n\
+             カスタムディレクトリを指定する場合は --opencode-dir オプションを使用してください。",
+            opencode_dir.display()
+        );
+    }
+
+    files.sort();
+    Ok(files)
+}
+
+pub fn collect_sessions(opencode_dir: &Path, filter: &DateFilter) -> Result<Vec<RawSession>> {
+    let db_paths = discover_history_files(opencode_dir)?;
+    let mut sessions: Vec<RawSession> = Vec::new();
+    for db_path in db_paths {
+        sessions.extend(collect_from_db(&db_path, filter)?);
+    }
+    Ok(sessions)
+}
+
+fn collect_from_db(db_path: &Path, filter: &DateFilter) -> Result<Vec<RawSession>> {
+    let conn = Connection::open(db_path)
+        .with_context(|| format!("Failed to open {}", db_path.display()))?;
+
+    let project_worktree = load_project_worktree(&conn)?;
+    let session_meta = load_session_meta(&conn, &project_worktree)?;
+    if session_meta.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut sessions: HashMap<String, RawSession> = session_meta
+        .into_iter()
+        .map(|(id, meta)| {
+            (
+                id.clone(),
+                RawSession {
+                    session_id: id,
+                    project: meta.project,
+                    project_path: meta.project_path,
+                    git_branch: None,
+                    user_entries: Vec::new(),
+                    assistant_entries: Vec::new(),
+                },
+            )
+        })
+        .collect();
+
+    // Map message_id → session_id, role, timestamp, tokens (populated as we
+    // read `message`) so we can attribute parts back to the assistant entry.
+    let mut message_index: HashMap<String, MessageIndexEntry> = HashMap::new();
+
+    {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, time_created, data \
+                 FROM message ORDER BY session_id, time_created, id",
+            )
+            .context("Failed to prepare opencode message query")?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })
+            .context("Failed to read opencode messages")?;
+
+        for row in rows {
+            let (message_id, session_id, time_created_ms, data_json) =
+                row.context("Failed to decode opencode message row")?;
+            if !sessions.contains_key(&session_id) {
+                continue;
+            }
+            if !filter.matches_unix_seconds(time_created_ms / 1_000) {
+                continue;
+            }
+            let Some(timestamp) = unix_ms_to_rfc3339(time_created_ms) else {
+                continue;
+            };
+            let data: Value = match serde_json::from_str(&data_json) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            let role = data.get("role").and_then(Value::as_str).unwrap_or("");
+
+            match role {
+                "assistant" => {
+                    let (input_tokens, output_tokens) = extract_tokens(&data);
+                    let session = sessions
+                        .get_mut(&session_id)
+                        .expect("session was validated above");
+                    let entry_index = session.assistant_entries.len();
+                    session.assistant_entries.push(ParsedAssistantEntry {
+                        timestamp: timestamp.clone(),
+                        message_count: 1,
+                        tool_uses: Vec::new(),
+                        input_tokens,
+                        output_tokens,
+                        file_paths: Vec::new(),
+                    });
+                    message_index.insert(
+                        message_id,
+                        MessageIndexEntry {
+                            session_id,
+                            role: MessageRole::Assistant { entry_index },
+                            timestamp,
+                        },
+                    );
+                }
+                "user" => {
+                    message_index.insert(
+                        message_id,
+                        MessageIndexEntry {
+                            session_id,
+                            role: MessageRole::User,
+                            timestamp,
+                        },
+                    );
+                }
+                _ => {
+                    // Unknown roles (e.g. system, tool) are not counted as
+                    // user turns; their parts are ignored so summary stats
+                    // stay accurate.
+                    continue;
+                }
+            }
+        }
+    }
+
+    {
+        let mut stmt = conn
+            .prepare(
+                "SELECT message_id, data \
+                 FROM part ORDER BY session_id, time_created, id",
+            )
+            .context("Failed to prepare opencode part query")?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .context("Failed to read opencode parts")?;
+
+        for row in rows {
+            let (message_id, data_json) = row.context("Failed to decode opencode part row")?;
+            let Some(index_entry) = message_index.get(&message_id) else {
+                continue;
+            };
+            let data: Value = match serde_json::from_str(&data_json) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            let Some(session) = sessions.get_mut(&index_entry.session_id) else {
+                continue;
+            };
+            let part_type = data.get("type").and_then(Value::as_str).unwrap_or("");
+
+            match (&index_entry.role, part_type) {
+                (MessageRole::User, "text") => {
+                    if let Some(text) = data.get("text").and_then(Value::as_str) {
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            session.user_entries.push(ParsedUserEntry {
+                                timestamp: index_entry.timestamp.clone(),
+                                text: truncate(trimmed, MAX_PROMPT_LEN),
+                            });
+                        }
+                    }
+                }
+                (MessageRole::Assistant { entry_index }, "tool") => {
+                    let tool_name = data
+                        .get("tool")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    if tool_name.is_empty() {
+                        continue;
+                    }
+                    let file_paths = extract_file_paths(&tool_name, &data);
+                    if let Some(entry) = session.assistant_entries.get_mut(*entry_index) {
+                        entry.tool_uses.push(tool_name);
+                        entry.file_paths.extend(file_paths);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut sessions: Vec<RawSession> = sessions.into_values().collect();
+    for session in &mut sessions {
+        session
+            .user_entries
+            .sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+        for entry in session.assistant_entries.iter_mut() {
+            entry.file_paths.sort();
+            entry.file_paths.dedup();
+        }
+    }
+    sessions.retain(|session| {
+        !session.user_entries.is_empty() || !session.assistant_entries.is_empty()
+    });
+
+    sessions.sort_by(|a, b| {
+        let left = a
+            .user_entries
+            .last()
+            .map(|entry| entry.timestamp.as_str())
+            .unwrap_or_default();
+        let right = b
+            .user_entries
+            .last()
+            .map(|entry| entry.timestamp.as_str())
+            .unwrap_or_default();
+        right.cmp(left)
+    });
+
+    Ok(sessions)
+}
+
+struct SessionMeta {
+    project: String,
+    project_path: String,
+}
+
+struct MessageIndexEntry {
+    session_id: String,
+    role: MessageRole,
+    timestamp: String,
+}
+
+enum MessageRole {
+    User,
+    Assistant { entry_index: usize },
+}
+
+fn load_project_worktree(conn: &Connection) -> Result<HashMap<String, String>> {
+    let mut stmt = conn
+        .prepare("SELECT id, worktree FROM project")
+        .context("Failed to prepare opencode project query")?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .context("Failed to read opencode projects")?;
+
+    let mut map = HashMap::new();
+    for row in rows {
+        let (id, worktree) = row.context("Failed to decode opencode project row")?;
+        map.insert(id, worktree);
+    }
+    Ok(map)
+}
+
+fn load_session_meta(
+    conn: &Connection,
+    project_worktree: &HashMap<String, String>,
+) -> Result<HashMap<String, SessionMeta>> {
+    let mut stmt = conn
+        .prepare("SELECT id, project_id, directory FROM session")
+        .context("Failed to prepare opencode session query")?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .context("Failed to read opencode sessions")?;
+
+    let mut map = HashMap::new();
+    for row in rows {
+        let (id, project_id, directory) = row.context("Failed to decode opencode session row")?;
+        // Prefer session.directory (per-session cwd) and fall back to the
+        // project worktree for the "global" pseudo-project or when directory
+        // was left empty.
+        let project_path = if !directory.is_empty() && directory != "/" {
+            directory
+        } else {
+            project_worktree
+                .get(&project_id)
+                .cloned()
+                .unwrap_or_default()
+        };
+        let project = extract_project_from_cwd(&project_path);
+        map.insert(
+            id,
+            SessionMeta {
+                project,
+                project_path,
+            },
+        );
+    }
+    Ok(map)
+}
+
+fn unix_ms_to_rfc3339(timestamp_ms: i64) -> Option<String> {
+    let seconds = timestamp_ms.div_euclid(1_000);
+    let nanos = (timestamp_ms.rem_euclid(1_000) * 1_000_000) as u32;
+    DateTime::<Utc>::from_timestamp(seconds, nanos).map(|dt| dt.to_rfc3339())
+}
+
+fn extract_tokens(message_data: &Value) -> (u64, u64) {
+    let tokens = message_data.get("tokens");
+    let input = tokens
+        .and_then(|value| value.get("input"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let output = tokens
+        .and_then(|value| value.get("output"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    (input, output)
+}
+
+fn extract_file_paths(tool_name: &str, part_data: &Value) -> Vec<String> {
+    let input = match part_data.get("state").and_then(|value| value.get("input")) {
+        Some(value) => value,
+        None => return Vec::new(),
+    };
+
+    let mut paths = Vec::new();
+    match tool_name {
+        "read" | "edit" | "write" => {
+            if let Some(path) = input.get("filePath").and_then(Value::as_str)
+                && !path.is_empty()
+            {
+                paths.push(path.to_string());
+            }
+        }
+        _ => {}
+    }
+
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max).collect();
+        format!("{truncated}...")
+    }
+}
+
+fn extract_project_from_cwd(cwd: &str) -> String {
+    if cwd.is_empty() {
+        return "unknown".to_string();
+    }
+    Path::new(cwd)
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| cwd.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::summarize_session;
+    use chrono::Duration;
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn create_schema(conn: &Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE project (
+                id TEXT PRIMARY KEY,
+                worktree TEXT NOT NULL
+            );
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                directory TEXT NOT NULL,
+                title TEXT NOT NULL DEFAULT '',
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL DEFAULT 0,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL DEFAULT 0,
+                data TEXT NOT NULL
+            );
+            ",
+        )
+        .expect("create schema");
+    }
+
+    fn write_db(path: &Path) {
+        let conn = Connection::open(path).expect("open db");
+        create_schema(&conn);
+        conn.execute(
+            "INSERT INTO project (id, worktree) VALUES (?1, ?2)",
+            ("proj-1", "/tmp/nippo"),
+        )
+        .expect("insert project");
+        conn.execute(
+            "INSERT INTO session (id, project_id, directory, title, time_created, time_updated) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            (
+                "ses-1",
+                "proj-1",
+                "/tmp/nippo",
+                "test",
+                1_776_144_000_000_i64,
+                1_776_144_500_000_i64,
+            ),
+        )
+        .expect("insert session");
+
+        // user message
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            (
+                "msg-u",
+                "ses-1",
+                1_776_144_000_000_i64,
+                r#"{"role":"user","time":{"created":1776144000000}}"#,
+            ),
+        )
+        .expect("insert user message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-u1",
+                "msg-u",
+                "ses-1",
+                1_776_144_000_000_i64,
+                r#"{"type":"text","text":"最初の指示"}"#,
+            ),
+        )
+        .expect("insert user text part");
+
+        // assistant message with tokens + tool part
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            (
+                "msg-a",
+                "ses-1",
+                1_776_144_100_000_i64,
+                r#"{"role":"assistant","tokens":{"input":11,"output":7},"time":{"created":1776144100000}}"#,
+            ),
+        )
+        .expect("insert assistant message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-a1",
+                "msg-a",
+                "ses-1",
+                1_776_144_101_000_i64,
+                r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"/tmp/nippo/crates/collector/src/main.rs"}}}"#,
+            ),
+        )
+        .expect("insert read tool");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-a2",
+                "msg-a",
+                "ses-1",
+                1_776_144_102_000_i64,
+                r#"{"type":"tool","tool":"edit","state":{"status":"completed","input":{"filePath":"/tmp/nippo/README.md","oldString":"a","newString":"b"}}}"#,
+            ),
+        )
+        .expect("insert edit tool");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-a3",
+                "msg-a",
+                "ses-1",
+                1_776_144_103_000_i64,
+                r#"{"type":"text","text":"作業しました"}"#,
+            ),
+        )
+        .expect("insert assistant text");
+
+        // second assistant message with a bash tool (no file path)
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            (
+                "msg-a2",
+                "ses-1",
+                1_776_144_200_000_i64,
+                r#"{"role":"assistant","tokens":{"input":5,"output":2}}"#,
+            ),
+        )
+        .expect("insert assistant2");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-b1",
+                "msg-a2",
+                "ses-1",
+                1_776_144_201_000_i64,
+                r#"{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls"}}}"#,
+            ),
+        )
+        .expect("insert bash tool");
+    }
+
+    #[test]
+    fn collects_opencode_sessions_from_sqlite() {
+        let dir = tempdir().expect("tempdir");
+        write_db(&dir.path().join("opencode.db"));
+
+        let filter = DateFilter::from_days(0);
+        let sessions = collect_sessions(dir.path(), &filter).expect("collect sessions");
+
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.session_id, "ses-1");
+        assert_eq!(session.project, "nippo");
+        assert_eq!(session.project_path, "/tmp/nippo");
+        assert_eq!(session.user_entries.len(), 1);
+        assert_eq!(session.user_entries[0].text, "最初の指示");
+        assert_eq!(session.assistant_entries.len(), 2);
+
+        let summary = summarize_session(session);
+        assert_eq!(summary.message_counts.user, 1);
+        assert_eq!(summary.message_counts.assistant, 2);
+        assert_eq!(summary.tool_usage.get("read"), Some(&1));
+        assert_eq!(summary.tool_usage.get("edit"), Some(&1));
+        assert_eq!(summary.tool_usage.get("bash"), Some(&1));
+        assert_eq!(summary.total_input_tokens, 16);
+        assert_eq!(summary.total_output_tokens, 9);
+        assert_eq!(
+            summary.files_touched,
+            vec!["README.md", "crates/collector/src/main.rs"]
+        );
+    }
+
+    #[test]
+    fn filters_by_local_day_bounds() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).expect("open");
+        create_schema(&conn);
+        conn.execute(
+            "INSERT INTO project (id, worktree) VALUES (?1, ?2)",
+            ("proj-1", "/tmp/nippo"),
+        )
+        .expect("insert project");
+
+        let filter = DateFilter::from_days(1);
+        let cutoff = filter.mtime_cutoff().expect("cutoff");
+        let cutoff_utc = DateTime::<Utc>::from(cutoff);
+        let inside_ms = cutoff_utc.timestamp_millis();
+        let outside_ms = (cutoff_utc - Duration::seconds(1)).timestamp_millis();
+
+        conn.execute(
+            "INSERT INTO session (id, project_id, directory, title, time_created, time_updated) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            ("ses-1", "proj-1", "/tmp/nippo", "t", outside_ms, inside_ms),
+        )
+        .expect("insert session");
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            (
+                "msg-old",
+                "ses-1",
+                outside_ms,
+                r#"{"role":"user","time":{"created":0}}"#,
+            ),
+        )
+        .expect("insert old message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-old",
+                "msg-old",
+                "ses-1",
+                outside_ms,
+                r#"{"type":"text","text":"too old"}"#,
+            ),
+        )
+        .expect("insert old part");
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            ("msg-new", "ses-1", inside_ms, r#"{"role":"user"}"#),
+        )
+        .expect("insert new message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-new",
+                "msg-new",
+                "ses-1",
+                inside_ms,
+                r#"{"type":"text","text":"kept"}"#,
+            ),
+        )
+        .expect("insert new part");
+
+        let sessions = collect_sessions(dir.path(), &filter).expect("collect");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].user_entries.len(), 1);
+        assert_eq!(sessions[0].user_entries[0].text, "kept");
+    }
+
+    #[test]
+    fn discover_history_files_returns_prod_and_dev_sorted() {
+        let dir = tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("opencode.db"), b"").expect("touch prod");
+        std::fs::write(dir.path().join("opencode-dev.db"), b"").expect("touch dev");
+
+        let files = discover_history_files(dir.path()).expect("discover");
+        // Both databases are returned and the order is deterministic
+        // (files.sort() yields dev before prod because `-` < `.` in ASCII).
+        assert_eq!(files.len(), 2);
+        assert!(files[0].ends_with("opencode-dev.db"));
+        assert!(files[1].ends_with("opencode.db"));
+    }
+
+    #[test]
+    fn collects_sessions_from_prod_and_dev_when_both_present() {
+        let dir = tempdir().expect("tempdir");
+        write_db(&dir.path().join("opencode.db"));
+
+        // A separate dev database holds a distinct session; the collector
+        // must read both files rather than stopping at the first match.
+        let dev_path = dir.path().join("opencode-dev.db");
+        let conn = Connection::open(&dev_path).expect("open dev");
+        create_schema(&conn);
+        conn.execute(
+            "INSERT INTO project (id, worktree) VALUES (?1, ?2)",
+            ("proj-dev", "/tmp/dev"),
+        )
+        .expect("insert dev project");
+        conn.execute(
+            "INSERT INTO session (id, project_id, directory, title, time_created, time_updated) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            (
+                "ses-dev",
+                "proj-dev",
+                "/tmp/dev",
+                "dev",
+                1_776_144_000_000_i64,
+                1_776_144_500_000_i64,
+            ),
+        )
+        .expect("insert dev session");
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            (
+                "msg-dev",
+                "ses-dev",
+                1_776_144_000_000_i64,
+                r#"{"role":"user"}"#,
+            ),
+        )
+        .expect("insert dev message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-dev",
+                "msg-dev",
+                "ses-dev",
+                1_776_144_000_000_i64,
+                r#"{"type":"text","text":"dev build"}"#,
+            ),
+        )
+        .expect("insert dev part");
+
+        let filter = DateFilter::from_days(0);
+        let sessions = collect_sessions(dir.path(), &filter).expect("collect");
+        let session_ids: Vec<&str> = sessions.iter().map(|s| s.session_id.as_str()).collect();
+        assert!(
+            session_ids.contains(&"ses-1"),
+            "prod session ses-1 missing: {session_ids:?}"
+        );
+        assert!(
+            session_ids.contains(&"ses-dev"),
+            "dev session ses-dev missing: {session_ids:?}"
+        );
+    }
+
+    #[test]
+    fn skips_messages_with_unknown_role() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).expect("open");
+        create_schema(&conn);
+        conn.execute(
+            "INSERT INTO project (id, worktree) VALUES (?1, ?2)",
+            ("proj-1", "/tmp/nippo"),
+        )
+        .expect("insert project");
+        conn.execute(
+            "INSERT INTO session (id, project_id, directory, title, time_created, time_updated) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            (
+                "ses-1",
+                "proj-1",
+                "/tmp/nippo",
+                "t",
+                1_776_144_000_000_i64,
+                1_776_144_500_000_i64,
+            ),
+        )
+        .expect("insert session");
+        // A `system` message and its part must not contribute to user_entries.
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            (
+                "msg-sys",
+                "ses-1",
+                1_776_144_000_000_i64,
+                r#"{"role":"system"}"#,
+            ),
+        )
+        .expect("insert system message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-sys",
+                "msg-sys",
+                "ses-1",
+                1_776_144_000_000_i64,
+                r#"{"type":"text","text":"system prompt"}"#,
+            ),
+        )
+        .expect("insert system part");
+        // A real user message so the session is not dropped as empty.
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4)",
+            (
+                "msg-u",
+                "ses-1",
+                1_776_144_100_000_i64,
+                r#"{"role":"user"}"#,
+            ),
+        )
+        .expect("insert user message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                "part-u",
+                "msg-u",
+                "ses-1",
+                1_776_144_100_000_i64,
+                r#"{"type":"text","text":"real user"}"#,
+            ),
+        )
+        .expect("insert user part");
+
+        let filter = DateFilter::from_days(0);
+        let sessions = collect_sessions(dir.path(), &filter).expect("collect");
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.user_entries.len(), 1);
+        assert_eq!(session.user_entries[0].text, "real user");
+    }
+
+    #[test]
+    fn discover_history_files_errors_when_missing() {
+        let dir = tempdir().expect("tempdir");
+        let err = discover_history_files(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("opencode の履歴データ"));
+    }
+}

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,6 +1,6 @@
 # データソース仕様
 
-Claude Code / Codex のセッションデータの保存場所と形式。
+Claude Code / Codex / opencode のセッションデータの保存場所と形式。
 
 ## 保存場所
 
@@ -121,6 +121,48 @@ SELECT id, cwd, git_branch, rollout_path FROM threads;
 - `git_branch`: ブランチ名
 - `rollout_path`: assistant 側の rollout JSONL へのパス
 
+## opencode の保存場所
+
+```
+~/.local/share/opencode/opencode.db
+~/.local/share/opencode/opencode-dev.db
+```
+
+- `opencode.db`: prod ビルドのメイン SQLite。セッション本体・メッセージ・パート・プロジェクトを保持
+- `opencode-dev.db`: dev ビルドの SQLite。存在すれば同じスキーマとして併読する
+- session_diff/ など `storage/` 配下の JSON は差分キャッシュで、`nippo` では読まない
+
+## opencode のスキーマ（使用列）
+
+```sql
+-- 各セッションのメタデータ
+SELECT id, project_id, directory, time_created, time_updated FROM session;
+
+-- session に対応するプロジェクト（`global` はホーム作業）
+SELECT id, worktree FROM project;
+
+-- 会話ログ。data は JSON 文字列
+SELECT id, session_id, time_created, data FROM message
+ORDER BY session_id, time_created, id;
+
+-- message に紐づくパート（テキスト・tool 呼び出し・reasoning など）
+SELECT id, message_id, session_id, time_created, data FROM part
+ORDER BY session_id, time_created, id;
+```
+
+- `session.directory`: 実行時の cwd。project.worktree より優先し、空か `/` なら worktree にフォールバック
+- `time_created` / `time_updated`: Unix ミリ秒（他ソースと違うので秒換算に注意）
+- `message.data`: `{"role":"user"|"assistant","tokens":{"input","output"},"time":{...}}` の JSON
+- `part.data`: `type` によって形が変わる
+  - `text` → `{"type":"text","text":"..."}`（user / assistant 双方の本文）
+  - `tool` → `{"type":"tool","tool":"read","state":{"input":{"filePath":"..."}}}`（tool_uses と file_paths を抽出）
+  - `step-start` / `step-finish` / `reasoning` → 集計しない
+
+`nippo` は message を先に読んで `user` / `assistant` のロールを確定し、その message_id に
+属する part を走査して text と tool を紐づける。tool 名は `data.tool`、ファイルパスは
+`read` / `edit` / `write` の `input.filePath` のみを対象にする（bash などの
+コマンドラインからのパス推定は行わない）。
+
 ## コレクター CLI オプション
 
 ```bash
@@ -139,9 +181,10 @@ nippo collect [OPTIONS]
 | `--include-self` | コマンドを実行している Claude Code / Codex セッションも含める | `false` |
 | `--max-sessions N` | 出力するセッション数の上限（0 = 無制限） | `0` |
 | `--format json\|summary` | 出力形式 | `json` |
-| `--source auto\|claude\|codex\|all` | データソース選択 | `auto` |
+| `--source auto\|claude\|codex\|opencode\|all` | データソース選択 | `auto` |
 | `--claude-dir PATH` | Claude データディレクトリ | `~/.claude` |
 | `--codex-dir PATH` | Codex データディレクトリ | `~/.codex` |
+| `--opencode-dir PATH` | opencode データディレクトリ | `~/.local/share/opencode` |
 
 `--period` の値: `today`, `yesterday`, `this-week`, `last-week`, `week-before-last`, `this-month`, `last-month`, `month-before-last`
 
@@ -178,4 +221,5 @@ JSON の `render_helpers` はローカル時刻のセッション範囲、30 分
 - `CODEX_THREAD_ID` があるときは `codex`
 - それ以外は Claude Code のデータがあれば `claude`
 - Claude がなく Codex があれば `codex`
-- 明示的に両方混ぜたいときだけ `--source all`
+- Claude も Codex もなく opencode のデータがあれば `opencode`
+- 明示的に混ぜたいときだけ `--source all`（利用可能な全ソースをマージ）

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -158,6 +158,9 @@ ORDER BY session_id, time_created, id;
   - `tool` → `{"type":"tool","tool":"read","state":{"input":{"filePath":"..."}}}`（tool_uses と file_paths を抽出）
   - `step-start` / `step-finish` / `reasoning` → 集計しない
 
+user message に複数の text part がある場合は改行で連結して 1 件として数える。
+`synthetic: true` または `ignored: true` の text part は利用者自身の指示ではないため除外する。
+
 `nippo` は message を先に読んで `user` / `assistant` のロールを確定し、その message_id に
 属する part を走査して text と tool を紐づける。tool 名は `data.tool`、ファイルパスは
 `read` / `edit` / `write` の `input.filePath` のみを対象にする（bash などの


### PR DESCRIPTION
Closes #22

## Summary
- opencode (https://opencode.ai/) の SQLite 履歴 (`~/.local/share/opencode/opencode.db`) を新しいデータソースとして追加
- `crates/collector/src/sources/opencode.rs` を新設し、`session` / `message` / `part` / `project` テーブルから `RawSession` を組み立て
- `message.data.role` は `user` / `assistant` を明示的に判定。未知の role (system / tool など) はスキップし、user 集計に混ぜない
- `--source` に `opencode` を追加、`--source all` は Claude + Codex + opencode に拡張
- `--source auto` は Claude → Codex → opencode の優先順位でフォールバック
- `--opencode-dir` オプションを追加（デフォルト `~/.local/share/opencode`）
- `time_created` / `time_updated` は Unix ミリ秒である点を踏まえ、他ソースの Unix 秒と混同しないよう変換
- README、`docs/data-sources.md`、Claude Code / Codex 両方の `SKILL.md` を同じ PR で更新

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace -- -D warnings`
- `cargo test --all-features --workspace` (59 passed, 0 failed; rebased on v0.1.7 main)
- 追加した opencode 関連テスト:
  - `collects_opencode_sessions_from_sqlite` — 単一 DB から session / message / part を組み立てる基本ケース
  - `filters_by_local_day_bounds` — DateFilter との連携
  - `discover_history_files_returns_prod_and_dev_sorted` — `opencode.db` と `opencode-dev.db` が併存する場合の並び順を固定
  - `collects_sessions_from_prod_and_dev_when_both_present` — 併存時に両 DB のセッションが返ることを end-to-end で確認
  - `skips_messages_with_unknown_role` — `system` などの未知 role がユーザー集計に混ざらないことを確認
  - `discover_history_files_errors_when_missing` — DB が無いときのエラー
- 手元で `nippo collect --source opencode --period today --format summary` を実行し、既存 opencode セッションが日報に反映されることを確認

## Compatibility
- 既存フラグの意味は変わらず、opencode 環境がない場合は従来どおり動作する
