### PR TITLE
feat(skill): accept named periods (yesterday, last-week, ...) as skill args

### DIFF
--- a/.agents/skills/nippo/SKILL.md
+++ b/.agents/skills/nippo/SKILL.md
@@ -13,6 +13,7 @@ Use this skill when the user wants to turn recent Claude Code or Codex work into
 - optional days
 - optional project filter
 - optional source override: `claude`, `codex`, `all`
+- optional period selector: `today`, `yesterday`, `this-week`, `last-week`, `week-before-last`, `this-month`, `last-month`, `month-before-last`
 
 Examples:
 
@@ -73,6 +74,7 @@ Examples:
 - If the first token is neither a mode name, a number, nor a source selector, treat it as a project filter and run the default daily mode with `--project`.
 - Date boundaries follow the machine's local timezone. `--days 1` and `daily` mean the current local calendar day.
 - Treat one token matching `claude`, `codex`, or `all` as the source selector and pass it through to `--source`.
+- Treat one token matching `today`, `yesterday`, `this-week`, `last-week`, `week-before-last`, `this-month`, `last-month`, or `month-before-last` as a period selector and pass it through to `--period`. In that case do not add the mode's default `--days` or default `--period today`; the explicit `--period` is the sole time-window flag. For `daily`, use `meta.period.to` from the collected JSON as the output filename date instead of computing it from the execution date.
 - `Codex` report data comes from `history.jsonl`, `state_5.sqlite`, and rollout data referenced by `rollout_path`. Treat `logs_2.sqlite` as diagnostics only.
 - Codex-derived reports may have sparse assistant/tool metrics. State that explicitly instead of inventing numbers.
 - For daily reports, copy `meta.source`, `meta.total_sessions`, `stats.projects_worked_on`, and `stats.tool_frequency` from the collected JSON instead of inferring them from an older report.

--- a/.claude/skills/nippo/SKILL.md
+++ b/.claude/skills/nippo/SKILL.md
@@ -62,7 +62,9 @@ context: fork
 
 `daily` は `(空)` と同じ日報モードのエイリアス。出力ファイル名は `reports/nippo-YYYY-MM-DD.md` を使う。
 
-残りトークンのうち `claude` / `codex` / `all` は `--source` に渡す。数値があれば `--days` を置換。それ以外の文字列は `--project` に渡す。先頭単語がモード名・数値・source のいずれでもない場合は日報モードとして扱い、その単語を `--project` に渡す。
+残りトークンのうち `claude` / `codex` / `all` は `--source` に渡す。`today` / `yesterday` / `this-week` / `last-week` / `week-before-last` / `this-month` / `last-month` / `month-before-last` は `--period` に渡す。この場合、モード既定の `--days` や `--period today` は付けない（明示された `--period` が唯一の期間指定になる）。数値があれば `--days` を置換。それ以外の文字列は `--project` に渡す。先頭単語がモード名・数値・source・period のいずれでもない場合は日報モードとして扱い、その単語を `--project` に渡す。
+
+`--period` を指定して `daily` を実行する場合、出力ファイル名の日付は collector が返す `meta.period.to` を使う。実行日から計算し直さない。
 
 ## 収集と生成
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,13 @@ nippo のリポジトリ内から `skill install` を実行した場合は、che
 /nippo daily claude       # Claude Code の履歴だけを使う
 /nippo daily codex        # Codex の履歴だけを使う
 /nippo daily all          # Claude Code と Codex の履歴をまとめる
+/nippo daily yesterday all  # 昨日分を Claude Code と Codex からまとめる
+$nippo daily yesterday all  # 同じことを Codex 側から
 ```
+
+`yesterday` の他に `today` / `this-week` / `last-week` / `week-before-last` /
+`this-month` / `last-month` / `month-before-last` を渡すと、`--period` として
+扱われます。
 
 source を指定しない場合は `auto` です。出力先は常にコマンドを実行した
 ディレクトリの `reports/` で、同じ日付・同じモードのファイルは最新の結果で


### PR DESCRIPTION
Closes #24

## Summary
- `/nippo daily yesterday all` のように period キーワードを skill 側の引数から素直に渡せるようにする
- `.claude/skills/nippo/SKILL.md` と `.agents/skills/nippo/SKILL.md` の引数パースルールに以下のトークンを追加し、見つけたら `--period <value>` に転送する
  - `today`, `yesterday`, `this-week`, `last-week`, `week-before-last`, `this-month`, `last-month`, `month-before-last`
- period 指定時は、モード既定の `--days` も `--period today` も付けない。明示された `--period` が唯一の期間指定になる
- 日報の出力ファイル名は collector が返す `meta.period.to` を使い、実行日から計算し直さない
- README のコマンド一覧に `/nippo daily yesterday all` と `$nippo daily yesterday all` の例を追加

## Motivation
- 日を跨いだ深夜に「昨日の日報」を出したいとき、既存だと `/nippo` は空、`/nippo 2 all` は両日混ざる、`yesterday` は project フィルタに流れる、で使えない
- ターミナルから直接 `nippo collect --period yesterday --source all` を叩けば済むが、skill 経由でも同じことができると朝の運用が楽になる

## Scope
- opencode source (`--source opencode`) 対応は #22 側の PR に含めた。この PR は skill の period 対応と README 例追加だけを含む

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace -- -D warnings`
- `cargo test --all-features --workspace` (53 passed, 0 failed; rebased on v0.1.7 main)
- 手元で `/nippo daily yesterday all` を発火し、`nippo collect --period yesterday --source all` に展開されて `reports/nippo-<yesterday>.md` として保存されることを確認
